### PR TITLE
Fix: Prevent pastebin function conflict

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -338,14 +338,19 @@ cdtmp() {
   cd "$path"
 }
 
-# Reads stdin into a URL to display the contents via https://topaz.github.io/paste
-# Data is stored in the URL and therefore is not at risk of being lost or leaked.
-# See also https://github.com/topaz/paste
-pastebin() {
-  printf 'https://topaz.github.io/paste/#'
-  lzma -c | base64 -w0
-  echo
-}
+# Only define the open-source pastebin function if a 'pastebin' command
+# or alias does not already exist. This allows other gems to provide a primary
+# implementation.
+if ! type -a pastebin >/dev/null 2>&1; then
+  # Reads stdin into a URL to display the contents via https://topaz.github.io/paste
+  # Data is stored in the URL and therefore is not at risk of being lost or leaked.
+  # See also https://github.com/topaz/paste
+  pastebin() {
+    printf 'https://topaz.github.io/paste/#'
+    lzma -c | base64 -w0
+    echo
+  }
+fi
 
 #
 # Git Functions


### PR DESCRIPTION
The pastebin() function causes a syntax error if another tool (like google.gem) has already defined a 'pastebin' alias.

This change wraps the function definition in a check to ensure it is only defined if no other command or alias named 'pastebin' already exists, establishing a clear precedence."