### PR TITLE
feat: Add tmux equivalent functions for screen utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ list of functionality provided.*
     own custom aliases, but `screenopen` gives lay-users easy access to
     `screen`'s key functionality - detachable shell sessions.
 
+*   `tmuxls`, `tmuxopen`, and `tmuxcmd` provide parallel functionality to the 
+    `screen` utilities for users of `tmux`.
+
 *   `gitsyncfork` syncs a Git repository with its upstream master. Useful for
     pulling in updates to a forked GitHub repo.
 
@@ -85,8 +88,8 @@ list of functionality provided.*
 
 ### Behavior
 
-*   Displays the names of any open `screen` sessions when a new shell is
-    launched.
+*   Displays the names of any open `screen` or `tmux` sessions when a new shell
+    is launched.
 
 ## Copyright and License
 

--- a/commands.sh
+++ b/commands.sh
@@ -18,7 +18,7 @@ fi
 
 if command -v tmuxls > /dev/null; then
   (
-    tmuxls=$(tmuxls)
+    tmuxls=$(tmuxls 2>/dev/null)
     if [[ -n "$tmuxls" ]]; then
       echo "Open tmux sessions: $(wc -w <<<"$tmuxls")"
       echo "  $(tr '\n' ' ' <<<"$tmuxls")"

--- a/commands.sh
+++ b/commands.sh
@@ -15,3 +15,14 @@ if command -v screens > /dev/null; then
     fi
   )
 fi
+
+if command -v tmuxls > /dev/null; then
+  (
+    tmuxls=$(tmuxls)
+    if [[ -n "$tmuxls" ]]; then
+      echo "Open tmux sessions: $(wc -w <<<"$tmuxls")"
+      echo "  $(tr '\n' ' ' <<<"$tmuxls")"
+    fi
+  )
+fi
+

--- a/functions.sh
+++ b/functions.sh
@@ -166,6 +166,36 @@ screencmd() {
 }
 fi # if screen is installed
 
+if command -v tmux > /dev/null; then
+# Prints the currently open tmux sessions.
+tmuxls() {
+  tmux list-sessions -F '#S'
+}
+
+# Opens a tmux session with a given name, either creating a new session or
+# attaching to one that already exists.
+tmuxopen() {
+  local session="${1:?Must specify a tmux session name.}"
+  tmux new-session -d -s "$session" 2>/dev/null || true
+  tmux attach-session -t "$session"
+}
+
+# Creates a tmux session (if it doesn't already exist), and then sends
+# the given commands to it.
+tmuxcmd() {
+  local session="${1:?Must specify a tmux session name.}"
+  shift
+  if (( $# == 0 )); then
+    pg::err "Must provide a command to run"
+    return 1
+  fi
+  tmux new-session -d -s "$session" 2>/dev/null || true
+  tmux send-keys -t "$session" "$*" C-m
+  printf "Wrote '%s' to '%s'\nTo open run:\n  tmuxopen '%s'\nthen <Ctrl>+b d to detach.\n" \
+    "$*" "$session" "$session"
+}
+fi # if tmux is installed
+
 # Grep ps command
 # Inspiration: http://www.commandlinefu.com/commands/view/977/
 # Alternately: http://code.google.com/p/psgrep/

--- a/info.txt
+++ b/info.txt
@@ -13,6 +13,7 @@ open             common alias for different systems' open-with-default-app
                  command; e.g. `open foo.png`.
 screenopen NAME  opens a screen session with useful defaults; detaches any
                  existing connection and logs the session to /tmp.
+tmuxopen NAME    opens a tmux session, creating or attaching as needed.
 wait_ext         blocks until the PIDs passed as arguments are finished.
 wait_port        blocks until the ports passed as arguments are listening for
                  requests.


### PR DESCRIPTION
This change introduces a parallel set of helper functions for tmux that mirror the existing functionality for GNU Screen.

- Adds `tmuxls`, `tmuxopen`, and `tmuxcmd` to `functions.sh` as equivalents for `screens`, `screenopen`, and `screencmd`.
- Adds a startup message to `commands.sh` to list active tmux sessions, matching the existing screen behavior.
- Updates README.md and info.txt to document the new functions.